### PR TITLE
allow for workspace with only sequencing_alignment table

### DIFF
--- a/PRIMED_genotype_data_model.json
+++ b/PRIMED_genotype_data_model.json
@@ -97,7 +97,7 @@
     },
     {
       "table": "sample_set",
-      "required": true,
+      "required": "CONDITIONAL (array_dataset, imputation_dataset, sequencing_dataset, simulation_dataset)",
       "columns": [
         {
           "column": "sample_set_id",
@@ -326,7 +326,7 @@
     },
     {
       "table": "sequencing_dataset",
-      "required": "CONDITIONAL (sequencing_file, sequencing_alignment)",
+      "required": "CONDITIONAL (sequencing_file)",
       "columns": [
         {
           "column": "sequencing_dataset_id",


### PR DESCRIPTION
the dataset table is no longer required when we include a sequencing_aligment table. thus, the sample_set table should depend on a dataset table being included, to make it possible to upload only sequencing_alignment data